### PR TITLE
Enable logger to receive arguments

### DIFF
--- a/framework/logger.py
+++ b/framework/logger.py
@@ -7,15 +7,25 @@ class Logger(object):
         self.start_time = time.time()
         logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
 
-    def warning(self, msg):
-        logging.warning(self.add_time(msg))
+    def warning(self, msg, *args, **kwargs):
+        logging.warning(self.add_time(msg), *args, **kwargs)
 
-    def info(self, msg):
-        logging.info(self.add_time(msg))
+    def warn(self, msg, *args, **kwargs):
+        logging.warning(self.add_time(msg), *args, **kwargs)
 
-    def debug(self, msg):
-        logging.debug(self.add_time(msg))
+    def info(self, msg, *args, **kwargs):
+        logging.info(self.add_time(msg), *args, **kwargs)
+
+    def debug(self, msg, *args, **kwargs):
+        logging.debug(self.add_time(msg), *args, **kwargs)
+
+    def log(self, msg, *args, **kwargs):
+        logging.log(self.add_time(msg), *args, **kwargs)
+
+    def error(self, msg, *args, **kwargs):
+        logging.error(self.add_time(msg), *args, **kwargs)
 
     def add_time(self, msg):
         time_spent = round((time.time() - self.start_time), 3)
-        return "[{}] {}".format(time_spent, msg)
+        msg_with_time = "[{}] {}".format(time_spent, msg)
+        return msg_with_time


### PR DESCRIPTION
文字列だけでなく、logging.info と同様に他の引数を受け取れるようにしました。

```
self.context.logger.info('%s before you %s', 'Look', 'leap!')
=> INFO:[0.001] Look before you leap!
```

