### PR TITLE
Issue/224/change repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# poc-base
+# podder-task
 
 This is base repository for PoC (Proof of Concept) code.
 Boilerplate project for creating python task using the [Pipeline-framework](https://github.com/podder-ai/pipeline-framework).
@@ -38,13 +38,13 @@ $ tree . -L 2
 
 ### How to implement a task class
 
-Add your code to `app/task.py`. 
+Add your code to `app/task.py`.
 
 #### Implementation sample
 
-Please check task sample here [Sample](https://github.com/podder-ai/poc-base-sample)
+Please check task sample here [Sample](https://github.com/podder-ai/podder-task-sample)
 
-#### __init__: Initialize task instance 
+#### __init__: Initialize task instance
 
 ```python
 def __init__(self, context: Context) -> None:
@@ -58,18 +58,18 @@ def __init__(self, context: Context) -> None:
 def execute(self) -> None:
 
     self.context.logger.debug("START processing...")
-    
+
     self.yourProcess(self.args.input_path)
-    
+
     self.context.logger.debug("Completed.")
-        
+
 ```
 
 #### set_arguments: Arguments
 
 ```python
 def set_arguments(self, parser) -> None:
-    
+
     parser.add_argument('--input_path', dest="input_path", help='set input path', default='.')
 
 ```
@@ -93,7 +93,7 @@ You can add your own command line argument using `self.context.config.set_argume
 
 After you execute with command line arguments, you can access to the passed arguments through `self.context.config.get`.
 
-For example, set `--model` to command line argument. 
+For example, set `--model` to command line argument.
 
 ```python
 # Set your command line argument
@@ -107,14 +107,14 @@ $ python main.py --model-path /path/to/model
 ```
 
 ```python
-# You can access to the value passed to "--model" 
+# You can access to the value passed to "--model"
 def execute(self, inputs: List[Any]) -> List[Any]:
     model = self.context.config.get('model_path')
 ```
 
 #### Shared directory
 
-You can use `shared` directory for storing your data. 
+You can use `shared` directory for storing your data.
 
 ```bash
 $ tree -L 1 ./shared
@@ -148,7 +148,7 @@ Please use `shared/tmp` directory for storing temporary files.
 ```python
 self.context.file.get_tmp_path('sample-tmp.csv')
 # => /path/to/shared/tmp/sample-tmp.csv
-``` 
+```
 
 ### Run
 
@@ -162,9 +162,9 @@ $ python main.py --inputs /path/to/input/a /path/to/input/b
 ### For Mac os, Linux user
 
 ```bash
-# clone poc-base
-$ git clone git@github.com:podder-ai/poc-base.git
-$ cd poc-base
+# clone podder-task
+$ git clone git@github.com:podder-ai/podder-task.git
+$ cd podder-task
 # enable python3
 $ python3 -m venv env
 $ source env/bin/activate
@@ -176,7 +176,7 @@ $ python main.py --inputs /path/to/input/a /path/to/input/b
 
 ### For Windows user with PowerShell
 
-If using Powershell, the activate script is subject to the execution policies on the system. By default on Windows 7, the system's excution policy is set to `Restricted`, meaning no scripts as virtualenv activation script are allowed to be executed. 
+If using Powershell, the activate script is subject to the execution policies on the system. By default on Windows 7, the system's excution policy is set to `Restricted`, meaning no scripts as virtualenv activation script are allowed to be executed.
 
 In order to use the script, you can relax your system's execution policy to `Unrestricted`, meaning all scripts on the system can be executed. As an administrator run:
 
@@ -185,9 +185,9 @@ C:\>Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force -Verbose
 ```
 
 ```bash
-# clone poc-base
-C:\> git clone git@github.com:podder-ai/poc-base.git
-C:\> cd poc-base
+# clone podder-task
+C:\> git clone git@github.com:podder-ai/podder-task.git
+C:\> cd podder-task
 # enable python3
 C:\>python3 -m venv C:\path\to\myenv
 # Windows cmd.exe
@@ -202,16 +202,16 @@ C:\> python main.py --inputs /path/to/input/a /path/to/input/b
 
 ### Via Docker
 
-To skip python environment setting, we are using Docker to run task. 
+To skip python environment setting, we are using Docker to run task.
 For detail Dockerfile check [here](./Dockerfile)
 
 
 ```bash
 # build docker image with python enviroment
-$ docker build -t poc-sample .
+$ docker build -t podder-task-sample .
 
 # run code
-$ docker run -ti poc-sample python main.py --inputs /path/to/input/a /path/to/input/b
+$ docker run -ti podder-task-sample python main.py --inputs /path/to/input/a /path/to/input/b
 ```
 
 ## Configuration
@@ -229,7 +229,7 @@ Please execute linters, formatters and unit tests before committing your source 
 ### How To Execute
 
 You can execute them by the following command.
-Make sure that you are under the root directory of your project. (e.q. poc-base/)
+Make sure that you are under the root directory of your project. (e.q. podder-task/)
 ```
 $ pip install -r ./requirements/requirements.develop.txt
 $ sh ./scripts/pre-commit.sh
@@ -266,5 +266,3 @@ To make it easier, please follow this implementation rules below.
 - Create virtual environment for your code. Please check [Creation of virtual environments](https://docs.python.org/3/library/venv.html)
 
 Please add issue & pull request if you have any request!
-
-

--- a/api/grpc_server.py
+++ b/api/grpc_server.py
@@ -4,12 +4,12 @@ DO NOT MODIFY THIS FILE.
 
 import os
 
-from api.task_api import PocBaseApi
+from api.task_api import PodderTaskApi
 from app import Task
 from podder_task_base.api.grpc_server import GrpcServer
 from protos import pipeline_framework_pb2_grpc
 
-DEFAULT_GRPC_PID_FILE = "/var/run/poc_base.pid"
+DEFAULT_GRPC_PID_FILE = "/var/run/podder_task.pid"
 DEFAULT_PORT = 50051
 DEFAULT_MAX_WORKERS = 10
 
@@ -24,5 +24,5 @@ if __name__ == '__main__':
         max_workers=os.getenv("GRPC_MAX_WORKERS", DEFAULT_MAX_WORKERS),
         port=os.getenv("GRPC_PORT", DEFAULT_PORT),
         execution_task=Task,
-        add_servicer_method=pipeline_framework_pb2_grpc.add_PocBaseApiServicer_to_server,
-        task_api_class=PocBaseApi).run()
+        add_servicer_method=pipeline_framework_pb2_grpc.add_PodderTaskApiServicer_to_server,
+        task_api_class=PodderTaskApi).run()

--- a/api/grpc_server.py
+++ b/api/grpc_server.py
@@ -9,7 +9,7 @@ from app import Task
 from podder_task_base.api.grpc_server import GrpcServer
 from protos import pipeline_framework_pb2_grpc
 
-DEFAULT_GRPC_PID_FILE = "/var/run/podder_task.pid"
+DEFAULT_GRPC_PID_FILE = "/var/run/poc_base.pid"
 DEFAULT_PORT = 50051
 DEFAULT_MAX_WORKERS = 10
 

--- a/api/protos/pipeline_framework.proto
+++ b/api/protos/pipeline_framework.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package pipeline_framework;
 
-service PocBaseApi {
+service PodderTaskApi {
     rpc execute (TaskResponse) returns (TaskResponse) {}
 }
 

--- a/api/task_api.py
+++ b/api/task_api.py
@@ -3,7 +3,7 @@ from protos import pipeline_framework_pb2_grpc
 from podder_task_base.api.task_api_executor import TaskApiExecutor
 
 
-class PocBaseApi(pipeline_framework_pb2_grpc.PocBaseApiServicer):
+class PodderTaskApi(pipeline_framework_pb2_grpc.PodderTaskApiServicer):
     def __init__(self, execution_task):
         self.execution_task = execution_task
 


### PR DESCRIPTION
以下のレポジトリ名の修正に関わるコード、ドキュメントの修正。
poc-base => podder-task
poc-base-generator => podder-task-generator
poc-base-sample => podder-task-sample
pipeline-framework => podder-pipeline
pipeline-framework-protos => podder-pipeline-protos
pipeline-builder => podder-pipeline-builder

なお、ATOMが勝手に改行コード等を修正してくれているようで、commit時のdiffで若干改行コードの修正等だけというのが混ざっています。特に問題はないと思いますが、ご了承ください。

●変更しない方針で作業している箇所は以下の通り

影響範囲が大きそうなので、以下のファイル（フォルダ）名は修正しなかったです。
/usr/local/poc_base
/var/run/poc_base.pid

gRPCの名前「pipeline_framework」は変更していません
