### PR TITLE
bugfix/remove_podder-task-base_in_requiments.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-podder-task-base>=0.3.0,<0.4.0


### PR DESCRIPTION
requiments.default.txt の方にpodder-task-baseを追記したのでこちらは不要になると思います。
また、podder-task-baseはユーザーが削除してしまうとまずいのでこちらのファイルにない方がいいと思っています。
https://github.com/podder-ai/podder-cli/pull/151